### PR TITLE
Possible solution for returning custom (binary) data

### DIFF
--- a/src/frapi/custom/Config/outputs.xml
+++ b/src/frapi/custom/Config/outputs.xml
@@ -27,6 +27,11 @@
    <default>0</default>
   </output>
   <output>
+   <name>Custom</name>
+   <enabled>1</enabled>
+   <default>0</default>
+  </output>
+  <output>
    <name>HTML</name>
    <enabled>1</enabled>
    <default>0</default>

--- a/src/frapi/library/Frapi/AllFiles.php
+++ b/src/frapi/library/Frapi/AllFiles.php
@@ -76,6 +76,7 @@ require LIBRARY_ROOT_PATH . DIRECTORY_SEPARATOR . 'Input' . DIRECTORY_SEPARATOR 
 
 // Response
 require LIBRARY_ROOT_PATH . DIRECTORY_SEPARATOR . 'Response.php';
+require LIBRARY_ROOT_PATH . DIRECTORY_SEPARATOR . 'Response/Custom.php';
 
 //Database
 require LIBRARY_ROOT_PATH . DIRECTORY_SEPARATOR . 'Database.php';
@@ -90,6 +91,7 @@ require LIBRARY_OUTPUT    . DIRECTORY_SEPARATOR . 'CLI.php';
 require LIBRARY_OUTPUT    . DIRECTORY_SEPARATOR . 'PHP.php';
 require LIBRARY_OUTPUT    . DIRECTORY_SEPARATOR . 'PRINTR.php';
 require LIBRARY_OUTPUT    . DIRECTORY_SEPARATOR . 'JS.php';
+require LIBRARY_OUTPUT    . DIRECTORY_SEPARATOR . 'Custom.php';
 
 // Security
 require LIBRARY_SECURITY  . DIRECTORY_SEPARATOR . 'Interface.php';

--- a/src/frapi/library/Frapi/Output.php
+++ b/src/frapi/library/Frapi/Output.php
@@ -109,6 +109,11 @@ class Frapi_Output
     {
         header('HTTP/1.1 '.intval($response->getStatusCode()));
 
+		$content_type = $response->getContentType();
+		if ($content_type) {
+			$this->mimeType = $content_type;
+		}
+
         header('Content-type: '.$this->mimeType.'; charset=utf-8');
 
         //IF debugging is turned on, then send cache info

--- a/src/frapi/library/Frapi/Output/Custom.php
+++ b/src/frapi/library/Frapi/Output/Custom.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Output Custom Content-Type
+ *
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://getfrapi.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@getfrapi.com so we can send you a copy immediately.
+ *
+ * This is the custom output.
+ *
+ * As you can see, this class is rather simple, it has a few
+ * methods that are from the interface and it is also
+ * using $response from the parent object.
+ *
+ * @license   New BSD
+ * @copyright echolibre ltd.
+ * @package   frapi
+ */
+class Frapi_Output_Custom  extends Frapi_Output implements Frapi_Output_Interface
+{
+    /**
+     * Custom Mime Type
+     *
+     * @var string
+     */
+    public $mimeType;
+
+    /**
+     * Populate the Output
+     *
+     * This method populates the $this->response
+     * variable with the value returned from the
+     * action.
+     *
+     * @param  Mixed $response Most of the times an array but could be
+     *                         an stdClass
+     * @param String $customTemplate The custom template file to use instead of the default one.
+     *
+     * @return void
+     */
+    public function populateOutput($response, $customTemplate = false)
+    {
+        $this->response = $response;
+        return $this;
+    }
+
+    /**
+     * Execute the output
+     *
+     * This method will basically return the value
+     * of $this->response with the desired type.
+     *
+     * In this case... binary data.
+     *
+     * @return string $this->response
+     */
+    public function executeOutput()
+    {
+        $returnedData = $this->response;
+
+        return $returnedData;
+    }
+}

--- a/src/frapi/library/Frapi/Output/XML.php
+++ b/src/frapi/library/Frapi/Output/XML.php
@@ -69,14 +69,13 @@ class Frapi_Output_XML extends Frapi_Output implements Frapi_Output_Interface
         }
 
         $xml = '';
-
+		
         $print = hash('md5', json_encode(
             $data + array('__action__name' => $this->action)
         ));
-
+		
         if ($response = Frapi_Internal::getCached($print)) {
             $this->response = json_decode($response);
-
         } elseif (file_exists($file)) {
             ob_start();
             echo '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
@@ -145,6 +144,18 @@ class Frapi_Output_XML extends Frapi_Output implements Frapi_Output_Interface
      */
     private function _generateXML($response)
     {
+		file_put_contents("/tmp/xml.log", __FILE__ .':'. __LINE__ . PHP_EOL);
+		if ($response instanceof DomNode) {
+			file_put_contents("/tmp/xml.log", __FILE__ .':'. __LINE__ . PHP_EOL);
+			return $response->ownerDocument->saveXML();
+		} elseif ($response instanceof XMLWriter) {
+			file_put_contents("/tmp/xml.log", __FILE__ .':'. __LINE__ . PHP_EOL);
+			return $response->outputMemory();
+		} elseif ($response instanceof SimpleXMLElement) {
+			file_put_contents("/tmp/xml.log", __FILE__ .':'. __LINE__ . PHP_EOL);
+			return $response->asXML();
+		}
+		
         //Create XMLWriter object
         $writer = new XMLWriter();
         //We want to write to memory

--- a/src/frapi/library/Frapi/Response.php
+++ b/src/frapi/library/Frapi/Response.php
@@ -28,6 +28,13 @@ class Frapi_Response
      */
     protected $http_code = 200;
 
+	/**
+	 * Content Type
+	 *
+	 * @var string
+	 */
+	protected $content_type = false;
+
     /**
      * The data to use in the output
      *
@@ -120,10 +127,33 @@ class Frapi_Response
      * This method sets the data variable to be used in the output.
      *
      * @param  array $data An array of data to set in the response.
-     * @return array An array of data to use in the output.
      */
     public function setData(array $data)
     {
         $this->data = $data;
     }
+
+	/**
+	 * Get the content type
+	 *
+	 * This method gets the content type for the return data
+	 *
+	 * @return string A valid mimetype
+	 */
+	public function getContentType()
+	{
+		return $this->content_type;
+	}
+
+	/**
+	 * Set the content type
+	 *
+	 * This method sets the content type for the return data
+	 *
+	 * @param string A valid mimetype
+	 */
+	public function setContentType($mimetype)
+	{
+		$this->content_type = $mimetype;
+	}
 }

--- a/src/frapi/library/Frapi/Response/Custom.php
+++ b/src/frapi/library/Frapi/Response/Custom.php
@@ -1,0 +1,15 @@
+<?php
+class Frapi_Response_Custom extends Frapi_Response
+{
+	/**
+     * Set the data
+     *
+     * This method sets the data variable to be used in the output.
+     *
+     * @param  string $data The data to set in the response.
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+}


### PR DESCRIPTION
David,

this is what I whipped up tonight, it seems to work — I can return JSON, and jpegs without issue...

```
<?php
$return = new Frapi_Response_Custom(array(
        'code' => '200',
        'data' => file_get_contents("/tmp/5336279902_4cd5a5c727_o.jpg"),
        'headers' => array('Content-Length' => filesize("/tmp/5336279902_4cd5a5c727_o.jpg"))
    ));

$return->setContentType('image/jpeg');

// or

$return = new Frapi_Response_Custom(array(
        'code' => '200',
        'data' => json_encode($this->toArray()),
    ));

$return->setContentType('application/json');
?>
```
