### PR TITLE
setting the action method's string into ActionContext

### DIFF
--- a/src/frapi/library/Frapi/Action.php
+++ b/src/frapi/library/Frapi/Action.php
@@ -152,6 +152,17 @@ class Frapi_Action
         $this->params = $params;
         return $this;
     }
+
+    /**
+     * Set the action context action method to be called, for reference
+     *
+     * @param string $action
+     */
+    public function setAction($action)
+    {
+        $this->action = $action;
+        return $this;
+    }
     
     /**
      * Retrieve the action we are invoking.

--- a/src/frapi/library/Frapi/Controller/Api.php
+++ b/src/frapi/library/Frapi/Controller/Api.php
@@ -143,7 +143,7 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
             $action = 'execute' . ucfirst(strtolower($method));
         }
 
-        $response = $this->actionContext->$action();
+        $response = $this->actionContext->setAction($action)->$action();
         
         // Make sure we use a Frapi_Response.
         if (!$response instanceof Frapi_Response) {


### PR DESCRIPTION
Frapi_Action has an $action property which seems to have been intended to contain the action method's name, but it was not getting set. 

This allows $this->action to be referenced in a Frapi_Action to know which method is to be called. 
