### PR TITLE
fix for bug when deleting actions

### DIFF
--- a/src/frapi/library/Lupin/Config/Helper/XmlArrayWriter.php
+++ b/src/frapi/library/Lupin/Config/Helper/XmlArrayWriter.php
@@ -103,6 +103,7 @@ class Lupin_Config_Helper_XmlArrayWriter
 
     public function isAssoc ($array)
     {
+        $array = (is_array($array)) ? array_merge(array(), $array) : $array;
         return (
             is_array($array) &&
             count(


### PR DESCRIPTION
fix action delete bug; reset array keys on numeric array before determining if isAssoc
