### PR TITLE
Fixed "default" parameter when param is not passed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 # Ignore the Netbeans nbproject folder
 #
 nbproject
+
+#
+# Ignore the PhpStorm project folder
+#
+.idea

--- a/src/frapi/library/Frapi/Action.php
+++ b/src/frapi/library/Frapi/Action.php
@@ -290,7 +290,7 @@ class Frapi_Action
      */
     protected function getParam($key, $type = self::TYPE_STRING, $default = null, $error_name = null)
     {
-        $param = isset($this->params[$key]) ? $this->params[$key] : null;
+        $param = isset($this->params[$key]) ? $this->params[$key] : $default;
 
         switch ($type) {
             case self::TYPE_FILE;

--- a/src/frapi/tests/unit-tests/library/Action/Public.php
+++ b/src/frapi/tests/unit-tests/library/Action/Public.php
@@ -162,4 +162,16 @@ class Action_Public extends Frapi_Action implements Frapi_Action_Interface
         return $this->toArray();
     }
 
+    /**
+     * Test getParam
+     * 
+     * This method exposes the protected getParam() method for
+     * unit-testing purposes.
+     * 
+     * @see Frapi_Action::getParam()
+     */
+    public function testGetParam($key, $type = self::TYPE_STRING, $default = null, $error_name = null)
+    {
+        return $this->getParam($key, $type, $default, $error_name);
+    }
 }

--- a/src/frapi/tests/unit-tests/library/Frapi/ActionTest.php
+++ b/src/frapi/tests/unit-tests/library/Frapi/ActionTest.php
@@ -33,7 +33,7 @@ class Frapi_ActionTest extends PHPUnit_Framework_TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp ()
+    protected function setUp()
     {
         parent::setUp();
     }
@@ -41,7 +41,7 @@ class Frapi_ActionTest extends PHPUnit_Framework_TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown ()
+    protected function tearDown()
     {
         parent::tearDown();
     }
@@ -49,14 +49,14 @@ class Frapi_ActionTest extends PHPUnit_Framework_TestCase
     /**
      * Tests Frapi_Action::getInstance()
      */
-    public function testGetInstanceActionExists ()
+    public function testGetInstanceActionExists()
     {
-        $action = Frapi_Action::getInstance('Testing1');
+        $action = MockFrapi_Action::getInstance('Public');
         $this->assertNotNull($action);
         $this->assertType('Frapi_Action', $action);
-        $this->assertEquals('Action_Testing1', get_class($action));
+        $this->assertEquals('Action_Public', get_class($action));
     }
-    
+
     public function testGetInstanceActionDoesNotExist()
     {
         $this->setExpectedException('Frapi_Action_Exception');
@@ -66,118 +66,136 @@ class Frapi_ActionTest extends PHPUnit_Framework_TestCase
     /**
      * Tests Frapi_Action->setActionFiles()
      */
-    public function testSetActionFiles ()
+    public function testSetActionFiles()
     {
         // TODO Auto-generated Frapi_ActionTest->testSetActionFiles()
         $this->markTestIncomplete("setActionFiles test not implemented");
         
         $this->action->setActionFiles(/* parameters */);
-    
     }
 
     /**
      * Tests Frapi_Action->setActionParams()
      */
-    public function testSetActionParams ()
+    public function testSetActionParams()
     {
         $actionParams = array('one' => 'one', 1 => 'two');
         
-        $action = Frapi_Action::getInstance('Testing1');
+        $action = MockFrapi_Action::getInstance('Public');
         $action->setActionParams($actionParams);
         $params = $action->getParams();
         
         $this->assertEquals($actionParams, $params);
     }
-    
+
     /**
      * Tests Frapi_Action->executeGet()
      */
-    public function testExecuteGet ()
+    public function testExecuteGet()
     {
         // TODO Auto-generated Frapi_ActionTest->testExecuteGet()
         $this->markTestIncomplete(
         "executeGet test not implemented");
         
         $this->action->executeGet(/* parameters */);
-    
     }
 
     /**
      * Tests Frapi_Action->executePut()
      */
-    public function testExecutePut ()
+    public function testExecutePut()
     {
         // TODO Auto-generated Frapi_ActionTest->testExecutePut()
         $this->markTestIncomplete(
         "executePut test not implemented");
         
         $this->action->executePut(/* parameters */);
-    
     }
 
     /**
      * Tests Frapi_Action->executePost()
      */
-    public function testExecutePost ()
+    public function testExecutePost()
     {
         // TODO Auto-generated Frapi_ActionTest->testExecutePost()
         $this->markTestIncomplete(
         "executePost test not implemented");
         
         $this->action->executePost(/* parameters */);
-    
     }
 
     /**
      * Tests Frapi_Action->executeDelete()
      */
-    public function testExecuteDelete ()
+    public function testExecuteDelete()
     {
         // TODO Auto-generated Frapi_ActionTest->testExecuteDelete()
         $this->markTestIncomplete(
         "executeDelete test not implemented");
         
         $this->action->executeDelete(/* parameters */);
-    
     }
 
     /**
      * Tests Frapi_Action->executeHead()
      */
-    public function testExecuteHead ()
+    public function testExecuteHead()
     {
         // TODO Auto-generated Frapi_ActionTest->testExecuteHead()
         $this->markTestIncomplete(
         "executeHead test not implemented");
         
         $this->action->executeHead(/* parameters */);
-    
+    }
+
+    /**
+     * Tests Frapi_Action->getParam() default value when a parameter is passed which differs from the default
+     */
+    public function testGetParamDefaultWhenPassed()
+    {
+        $actionParams = array('key1' => 'value1');
+        $action = MockFrapi_Action::getInstance('Public');
+        $action->setActionParams($actionParams);
+        $param = $action->testGetParam('key1', Action_Public::TYPE_STRING, 'value2');
+
+        $this->assertEquals($param, 'value1');
+    }
+
+    /**
+     * Tests Frapi_Action->getParam() default value when a parameter is not passed
+     */
+    public function testGetParamDefaultWhenNotPassed()
+    {
+        $actionParams = array('key1' => 'value1');
+        $action = MockFrapi_Action::getInstance('Public');
+        $action->setActionParams($actionParams);
+        $param = $action->testGetParam('key2', Action_Public::TYPE_STRING, 'value2');
+
+        $this->assertEquals($param, 'value2');
     }
 
     /**
      * Tests Frapi_Action->getParams()
      */
-    public function testGetParams ()
+    public function testGetParams()
     {
         // TODO Auto-generated Frapi_ActionTest->testGetParams()
         $this->markTestIncomplete(
         "getParams test not implemented");
         
         $this->action->getParams(/* parameters */);
-    
     }
 
     /**
      * Tests Frapi_Action->getFiles()
      */
-    public function testGetFiles ()
+    public function testGetFiles()
     {
         // TODO Auto-generated Frapi_ActionTest->testGetFiles()
         $this->markTestIncomplete(
         "getFiles test not implemented");
         
         $this->action->getFiles(/* parameters */);
-    
     }
 
 }


### PR DESCRIPTION
I fixed the usage of the default parameter when a param is not passed in an API call (for issue #70).

Furthermore:
- Included 2 unit-tests to reproduce. Had to add a method to the Action_Public class to expose the getParam() method to the tests. If you have a more proper way, let me know. I noticed there's a nicer solution for PHP 5.3 (Reflection), but this would break the PHP 5.2.x compatibility, which is the version I'm using.
- Fixed some broken tests to let the whole ActionTest succeed.
- Added ignore line for PhpStorm IDE project files.
