### PR TITLE
Let console tool's ROOT_PATH be set via env var

### DIFF
--- a/src/frapi/admin/application/modules/default/models/Action.php
+++ b/src/frapi/admin/application/modules/default/models/Action.php
@@ -11,6 +11,7 @@
  * to license@getfrapi.com so we can send you a copy immediately.
  *
  * @license   New BSD
+ * @copyright echolibre ltd.
  * @package   frapi-admin
  */
 class Default_Model_Action extends Lupin_Model
@@ -389,7 +390,7 @@ class Default_Model_Action extends Lupin_Model
             );
 
             $default = $class->getProperty('requiredParams');
-            if ($default->getDefaultValue()->getValue() != $properties) {
+            if (is_object($default) && ($default->getDefaultValue()->getValue() != $properties)) {
                 $default->setSourceDirty(true);
                 $class->setProperty($default->setDefaultValue($properties));
             }

--- a/src/frapi/admin/console/frapi.php
+++ b/src/frapi/admin/console/frapi.php
@@ -18,7 +18,7 @@
  */
 
 // Define path to application directory
-define('ROOT_PATH', dirname(dirname(dirname(__FILE__))));
+define('ROOT_PATH', (getenv('FRAPI_ROOT_PATH') ? getenv('FRAPI_ROOT_PATH') : dirname(dirname(dirname(__FILE__)))));
 define('APPLICATION_PATH', ROOT_PATH . DIRECTORY_SEPARATOR .
        'admin' . DIRECTORY_SEPARATOR.'application');
 define('CONSOLE_CONTROLLERS_PATH', APPLICATION_PATH . DIRECTORY_SEPARATOR .


### PR DESCRIPTION
At FictiveKin we have a setup with two separate FRAPI installs, symlinking the shared libs but keeping the custom dirs separate. Allowing us to set the ROOT_PATH via env var lets us use the console tool; otherwise PHP resolves the symlinks and won't find the custom dir.
