### PR TITLE
HTTP_X_FORWARDED_FOR handling in HTTP Digest Authentication

### DIFF
--- a/src/frapi/library/Frapi/Authorization/HTTP/Digest.php
+++ b/src/frapi/library/Frapi/Authorization/HTTP/Digest.php
@@ -141,10 +141,13 @@ class Frapi_Authorization_HTTP_Digest extends Frapi_Authorization implements Fra
     public function getNonce()
     {
         $time = ceil(time() / $this->nonceLife) * $this->nonceLife;
+        $remoteAddress = isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? 
+            $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'];
+
         return hash(
             'md5',
             date('Y-m-d H:i', $time) . ':' .
-                $_SERVER['REMOTE_ADDR'] . ':' .
+                $remoteAddress . ':' .
                 $this->secretKey
         );
     }


### PR DESCRIPTION
- When doing HTTP Digest authentication the nonce is created using the IP of the
  issuer. In the event where the request goes through a load-balancer(s) setup, 
  the REMOTE_ADDR then becomes the address of the load-balancer. This patch adds 
  the ability to use the HTTP_X_FORWARDED_FOR variable which resolves the issue
