### PR TITLE
A fix for passing in JSON/XML as request body and parsing as data

### DIFF
--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -357,7 +357,7 @@ class Frapi_Controller_Main
          */
         if (end($puts) == '' && !empty($inputFormat) || !empty($xmlJsonMatch)) {
             /* attempt to parse the input */
-            rewind($puts);
+            reset($puts);
             $requestBody = Frapi_Input_RequestBodyParser::parse(
                 $inputFormat,
                 $input

--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -342,13 +342,27 @@ class Frapi_Controller_Main
             $xmlJsonMatch = preg_grep('/\<|\{/i', array_keys($puts));
             $inputFormat = $this->getFormat();
         }
-        if (empty($puts) && !empty($inputFormat) || !empty($xmlJsonMatch)) {
+        
+        /**
+         * When doing parse_str("{json:string}") it creates an array like:
+         * array(
+         *  "{json:string}" => ""
+         * )
+         * 
+         * If args are also present along with the body, they are in the array
+         * before the body.
+         * 
+         * Checks if the last argument is an empty string, this + inputForm is 
+         * indicative of the body needing parsing.
+         */
+        if (end($puts) == '' && !empty($inputFormat) || !empty($xmlJsonMatch)) {
             /* attempt to parse the input */
+            rewind($puts);
             $requestBody = Frapi_Input_RequestBodyParser::parse(
                 $inputFormat,
                 $input
             );
-
+            
             if (!empty($requestBody)) {
                 $rootElement = array_keys($requestBody);
 


### PR DESCRIPTION
When doing `parse_str(file_get_contents("php://input"), $data)` it creates an array like:  

```
 array(
      "{json:string}" => ""
 )
```

If args are also present along with the body, they are in the parse_str array before the body.

This means that `empty($data)` is returning false. 

This fix checks the last element for being empty, along with the $inputFormat we can make a pretty good guess that it's meant to be parsed.
