### PR TITLE
Don't try to use the controller outside of the try

### DIFF
--- a/src/frapi/library/Frapi/Controller/Api.php
+++ b/src/frapi/library/Frapi/Controller/Api.php
@@ -201,17 +201,26 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
     {
         try {
             $controller = new Frapi_Controller_Api();
-        } catch (Exception $e) {
-            // This is a hack to intercept anything that may
-            // have happened before the internal error collection
-            // during the initialisation process.
-        }
 
-        return $controller->getOutputInstance($controller->getFormat())
+            return $controller->getOutputInstance($controller->getFormat())
                           ->setOutputAction('defaultError')
                           ->populateOutput($e->getErrorArray())
                           ->sendHeaders($e)
                           ->executeOutput();
+        } catch (Exception $e) {
+            // This is a hack to intercept anything that may
+            // have happened before the internal error collection
+            // during the initialisation process.
+            //
+            // If we got here, we have no controller and cannot properly handle
+            // output, so we just send a 500 and die.
+
+
+            header("HTTP/1.0 500 Internal Server Error");
+            exit;
+        }
+
+
     }
 
     /**


### PR DESCRIPTION
If an error occurs trying to instantiate the controller during error handling, it is thrown as an exception and we skip to the `catch`, leaving the `$controller` var is undefined. Currently it then still tries to use `$controller` resulting in a fatal error.

To resolve this we move the use of `$controller` into the `try` block and because we can't handle the formatted output, we send a format-agnostic HTTP 500 error with no body in the `catch`.
