### PR TITLE
Add support for params in mimetypes

### DIFF
--- a/src/frapi/admin/application/modules/default/models/Mimetype.php
+++ b/src/frapi/admin/application/modules/default/models/Mimetype.php
@@ -68,7 +68,7 @@ class Default_Model_Mimetype extends Lupin_Model
         // Validate the mimetype doesn't already exist and is valid
         if (in_array($data['mimetype'], $this->getList())) {
             throw new RuntimeException('Mimetype already exists.');
-        } else if (!preg_match('/^[a-z]+\/[a-z]([a-z0-9\-\.]+)?(\+[a-z0-9\-\.]+)?$/', $data['mimetype'])) {
+        } else if (!preg_match('/^:?[a-z]+\/:?[a-z]([:a-z0-9\-\.]+)?(\+[:a-z0-9\-\.]+)?$/', $data['mimetype'])) {
             throw new RuntimeException('Mimetype does not validate.');
         }
         

--- a/src/frapi/admin/application/modules/default/views/scripts/mimetypes/add.phtml
+++ b/src/frapi/admin/application/modules/default/views/scripts/mimetypes/add.phtml
@@ -1,1 +1,22 @@
 <?php echo $this->form; ?>
+<script type="text/javascript">
+$(document).ready(function() {
+    if ($('#mimetype').val() == '') {
+        $('#mimetype').val('text/:var');
+    }
+
+    $('#mimetype').focus(function() {
+        if ($('#mimetype').val() == 'text/:var') {
+            $(this).val('');
+        }
+    });
+
+    $('#mimetype').blur(function() {
+        if ($(this).val() == '') {
+            $(this).val('text/:var')
+        }
+    });
+
+    $('#output_format').after($("<p style='margin-left: 185px; margin-top: -2em; font-size: 10px'><em>You may use a :var instead of an <a href='/output'>output type</a>.</em></p>"))
+});
+</script>

--- a/src/frapi/library/Frapi/Action.php
+++ b/src/frapi/library/Frapi/Action.php
@@ -61,6 +61,13 @@ class Frapi_Action
     protected $params;
 
     /**
+     * The parameters passed in via the Accept header
+     *
+     * @var array $params
+     */
+    protected $acceptParams;
+
+    /**
      * Those are the files uploaded to the server.
      *
      * @var mixed $params  The values of the $_FILES variable
@@ -142,6 +149,17 @@ class Frapi_Action
         $this->action = isset($params['action']) ? $params['action'] : null;
 
         $this->params = $params;
+        return $this;
+    }
+
+    /**
+     * Set the Accept header parameters
+     *
+     * @param array $params The params parsed from the Accept header
+     */
+    public function setAcceptParams(array $params)
+    {
+        $this->acceptParams = $params;
         return $this;
     }
 
@@ -258,6 +276,19 @@ class Frapi_Action
     }
 
     /**
+     * Return all the Accept parameters
+     *
+     * Return all the accept parameters we are currently holding
+     * in $this->acceptParams
+     *
+     * @return array An array of request parameters and files maybe.
+     */
+    public function getAcceptParams()
+    {
+        return $this->acceptParams;
+    }
+
+    /**
      * Return the files uploaded
      *
      * This method is exactly like $this->getParams() however
@@ -274,6 +305,40 @@ class Frapi_Action
     /**
      * This method will return the value of the
      * parameter. If it's not set then it returns null.
+     *
+     * @param string $key        The name of the param key
+     * @param string $type       The type of casting to do when returning
+     *                           the requested parameter
+     * @param Mixed  $default    The default value, if param is empty.
+     * @param String $error_name The error name to raise, as last resort.
+     *
+     * @return Mixed String when the key is valid, ErrorContext if not valid, or null if not set.
+     */
+    protected function getParam($key, $type = self::TYPE_STRING, $default = null, $error_name = null)
+    {
+         return $this->getByKey($this->params, $key, $type, $default, $error_name);
+    }
+
+    /**
+     * This method will return the value of the Accepts
+     * parameter. If it's not set then it returns null.
+     *
+     * @param string $key        The name of the param key
+     * @param string $type       The type of casting to do when returning
+     *                           the requested parameter
+     * @param Mixed  $default    The default value, if param is empty.
+     * @param String $error_name The error name to raise, as last resort.
+     *
+     * @return Mixed String when the key is valid, ErrorContext if not valid, or null if not set.
+     */
+    protected function getAcceptParam($key, $type = self::TYPE_STRING, $default = null, $error_name = null)
+    {
+         return $this->getByKey($this->acceptParams, $key, $type, $default, $error_name);
+    }
+
+    /**
+     * This method will return the value from the array, by key.
+     * If it's not set then it returns null.
      *
      * The function is coded such that FALSE is known to indicate
      * non-existence of param in $params, NULL indicates that
@@ -294,9 +359,9 @@ class Frapi_Action
      *
      * @return Mixed String when the key is valid, ErrorContext if not valid, or null if not set.
      */
-    protected function getParam($key, $type = self::TYPE_STRING, $default = null, $error_name = null)
+    protected function getByKey(array $array, $key, $type = self::TYPE_STRING, $default = null, $error_name = null)
     {
-        $param = isset($this->params[$key]) ? $this->params[$key] : $default;
+        $param = isset($this->acceptParams[$key]) ? $this->acceptParams[$key] : $default;
 
         switch ($type) {
             case self::TYPE_FILE;
@@ -357,5 +422,16 @@ class Frapi_Action
     protected function hasParam($key)
     {
         return isset($this->params[$key]);
+    }
+
+    /**
+     * This method checks whether an Accept param exists or not.
+     *
+     * @param string $key The name of the param key
+     * @return bool Whether the parameter exists or not
+     */
+    protected function hasAcceptParam($key)
+    {
+        return isset($this->acceptParams[$key]);
     }
 }


### PR DESCRIPTION
- This can used for versioning resources
- Dynamic formats

Example: `application/vnd.:vendor.:version+:format`

Additionally, RFC compliant parameters are now supported, this allows for mimetypes like:
- `text/html;charset=utf-8`
- `application/json;version=1`
- `text/json, application/xml;q=0.5`

As per spec:
- Quoting of values is optional
- `level` and `q` are no longer synonymous

All of the params are available in actions using
`->getAcceptParams()`, `getAcceptParam($key)` and
`hasAcceptParam($key)`.

Defined `:var` params will override user-specified
mimetype params.
