### PR TITLE
Fix issue when using extension for format

### DIFF
--- a/src/frapi/library/Frapi/Controller/Api.php
+++ b/src/frapi/library/Frapi/Controller/Api.php
@@ -342,8 +342,10 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
         }
 
         if ($this->formatSetByExtension) {
-            $this->setformat(strtolower($this->format));
-            return true;
+            return array(
+                'mimeType' => $this->setformat(strtolower($this->format)),
+                'outputFormat' => $this->format,
+            );
         }
 
         $mimetypes = $this->parseMimeTypes();

--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -465,6 +465,9 @@ class Frapi_Controller_Main
         if ($format) {
             $typeValid = Frapi_Rules::validateOutputType($format);
             $this->format = $format;
+
+            $mimetypes = array_flip($this->mimeMaps);
+            return $mimetypes[$this->format];
         } else {
             throw new Frapi_Error (
                 Frapi_Error::ERROR_INVALID_URL_PROMPT_FORMAT_NAME,


### PR DESCRIPTION
In the case where an extension is given, there was a boolean returned from `Frapi_Controller_Api->detectAndSetMimeType()` which was then passed into `Frapi_Action->setAcceptParams(array $params)` causing an `E_RECOVERABLE_ERROR` that results in an exception.

``` json

{
    "errors": [
        {
            "message": "Argument 1 passed to Frapi_Action::setAcceptParams() must be an array, boolean given, called in /Library/WebServer/Documents/frapi/src/frapi/library/Frapi/Controller/Api.php on line 245 and defined (Error Number: 4096), (File: /Library/WebServer/Documents/frapi/src/frapi/library/Frapi/Action.php at line 160)", 
            "name": "PHP Recoverable error", 
            "at": ""
        }
    ]
}
```
