### PR TITLE
allow customized Frapi_Authorization to be injected into the Main controller

### DIFF
--- a/src/frapi/library/Frapi/Controller/Api.php
+++ b/src/frapi/library/Frapi/Controller/Api.php
@@ -48,10 +48,11 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
      * @see $this->setFormat()
      * @see Error
      * @uses Error
+     * @param Frapi_Authorization $customAuthorization optional custom authorization
      */
-    public function __construct()
+    public function __construct($customAuthorization=null)
     {
-        parent::__construct();
+        parent::__construct($customAuthorization);
         $this->options = $this->detectAndSetMimeType();
     }
 

--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -189,13 +189,13 @@ class Frapi_Controller_Main
      * @see Security
      * @see ErrorContainer
      * @see Authorization
-     * @see Frapi_Router
+     * @params object $customAuthorization optional custom authorization extending Frapi_Authorization
      */
-    public function __construct()
+    public function __construct($customAuthorization=null)
     {
         try {
             $this->security      = new Frapi_Security();
-            $this->authorization = new Frapi_Authorization();
+            $this->authorization = ($customAuthorization instanceof Frapi_Authorization) ? $customAuthorization : new Frapi_Authorization();
             $this->router        = new Frapi_Router();
 
 

--- a/src/frapi/public/index.php
+++ b/src/frapi/public/index.php
@@ -4,9 +4,10 @@ require dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'library/Frapi/AllFil
 set_error_handler(array('Frapi_Error', 'errorHandler'), E_ALL);
 
 try {
-    if(!isset($customAuthorization))
+    if(!isset($customAuthorization)) {
         $customAuthorization = null;
-    
+    }
+
     $controller = new Frapi_Controller_Api($customAuthorization);
 
     try {

--- a/src/frapi/public/index.php
+++ b/src/frapi/public/index.php
@@ -4,7 +4,10 @@ require dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'library/Frapi/AllFil
 set_error_handler(array('Frapi_Error', 'errorHandler'), E_ALL);
 
 try {
-    $controller = new Frapi_Controller_API();
+    if(!isset($customAuthorization))
+        $customAuthorization = null;
+    
+    $controller = new Frapi_Controller_Api($customAuthorization);
 
     try {
         $controller->authorize();


### PR DESCRIPTION
[resubmit without conflicting commits]

This allows customization of a Frapi_Authorization object before startup, so that the authentication handler can be replaced or extended.

In my case, this was necessary due to long-running uploads that extend beyond the lifetime of a standard request nonce. I created a custom extension of Frapi_Authorization / Frapi_Authorization_Partner that can override nonce lifetimes by action, and needed a way to inject it.

If anyone has issues with this, or a better approach let's discuss. (The ability to customize nonce lifetime might be worth adding as a feature itself, as anytime you're handling non-trivial uploads with FRAPI this is going to crop up.) 
