### PR TITLE
Updated getByKey() in src/frapi/library/Frapi/Action.php to return the default value (null) without casting it if empty or !isset()

### DIFF
--- a/src/frapi/library/Frapi/Action.php
+++ b/src/frapi/library/Frapi/Action.php
@@ -362,9 +362,13 @@ class Frapi_Action
     protected function getByKey(array $array, $key, $type = self::TYPE_STRING, $default = null, $error_name = null)
     {
         if (isset($array[$key]))
+        {
             $param = $array[$key];
+        }
         else
+        {
             return $default;
+        }
 
         switch ($type) {
             case self::TYPE_FILE;

--- a/src/frapi/library/Frapi/Action.php
+++ b/src/frapi/library/Frapi/Action.php
@@ -361,12 +361,9 @@ class Frapi_Action
      */
     protected function getByKey(array $array, $key, $type = self::TYPE_STRING, $default = null, $error_name = null)
     {
-        if (isset($array[$key]))
-        {
+        if (isset($array[$key])) {
             $param = $array[$key];
-        }
-        else
-        {
+        } else {
             return $default;
         }
 

--- a/src/frapi/library/Frapi/Action.php
+++ b/src/frapi/library/Frapi/Action.php
@@ -361,7 +361,10 @@ class Frapi_Action
      */
     protected function getByKey(array $array, $key, $type = self::TYPE_STRING, $default = null, $error_name = null)
     {
-        $param = isset($array[$key]) ? $array[$key] : $default;
+        if (isset($array[$key]))
+            $param = $array[$key];
+        else
+            return $default;
 
         switch ($type) {
             case self::TYPE_FILE;


### PR DESCRIPTION
Previously, passing an empty non-required param to getParam(), returned the default value (null) casted as aksed to getParam(), so $value == NULL, would never happen.
Now, it will return the default value, without casting it.

When "$param == $default", I think it souldn't pass in the switch.
