### PR TITLE
Allow CUSTOM directory to be located anywhere

### DIFF
--- a/src/frapi/admin/application/Bootstrap.php
+++ b/src/frapi/admin/application/Bootstrap.php
@@ -45,7 +45,7 @@ class Bootstrap extends Zend_Application_Bootstrap_Bootstrap
     {
         Zend_Registry::set('config', new Zend_Config($this->getOptions()));
 
-        $localConfigPath = ROOT_PATH . DIRECTORY_SEPARATOR . 'custom' .
+        $localConfigPath = CUSTOM_PATH .
                           DIRECTORY_SEPARATOR . 'Config' . DIRECTORY_SEPARATOR;
 
         Zend_Registry::set('localConfigPath', $localConfigPath);

--- a/src/frapi/admin/application/modules/console/controllers/ActionController.php
+++ b/src/frapi/admin/application/modules/console/controllers/ActionController.php
@@ -193,7 +193,7 @@ class Console_ActionController extends Zend_Controller_Action
     {
         $this->_helper->viewRenderer->setViewSuffix('txt');
 
-        $dir  = ROOT_PATH . DIRECTORY_SEPARATOR . 'custom' . DIRECTORY_SEPARATOR . 'Action';
+        $dir  = CUSTOM_PATH . DIRECTORY_SEPARATOR . 'Action';
 
         if (!is_writable($dir)) {
             $this->view->message = $this->tr->_('ACTION_WRITE_ERROR', $dir) . PHP_EOL;

--- a/src/frapi/admin/application/modules/default/controllers/ActionController.php
+++ b/src/frapi/admin/application/modules/default/controllers/ActionController.php
@@ -140,7 +140,7 @@ class ActionController extends Lupin_Controller_Base
         $name       = $actionData['name'];
         $file       = strtolower($name) . '.php';
 
-        $dir = ROOT_PATH . DIRECTORY_SEPARATOR . 'custom' . DIRECTORY_SEPARATOR . 'Action';
+        $dir = CUSTOM_PATH . DIRECTORY_SEPARATOR . 'Action';
         $file = $dir . DIRECTORY_SEPARATOR . ucfirst($file);
 
         if ($this->_request->isPost()) {
@@ -263,7 +263,7 @@ class ActionController extends Lupin_Controller_Base
         $this->_helper->viewRenderer->setNoRender();
         $model = new Default_Model_Action;
 
-        $dir  = ROOT_PATH . DIRECTORY_SEPARATOR . 'custom' . DIRECTORY_SEPARATOR . 'Action';
+        $dir  = CUSTOM_PATH . DIRECTORY_SEPARATOR . 'Action';
         if (!is_writable($dir)) {
             $this->addMessage(sprintf($this->tr->_('ACTION_WRITE_ERROR'), $dir));
             $this->_redirect('/action');
@@ -276,7 +276,7 @@ class ActionController extends Lupin_Controller_Base
     public function testAction()
     {
         $name = 'Testing1';
-        $dir  = ROOT_PATH . DIRECTORY_SEPARATOR . 'custom' . DIRECTORY_SEPARATOR . 'Action';
+        $dir  = CUSTOM_PATH . DIRECTORY_SEPARATOR . 'Action';
         $file = $dir . DIRECTORY_SEPARATOR . $name . '.php';
         require_once $file;
 

--- a/src/frapi/admin/application/modules/default/controllers/IndexController.php
+++ b/src/frapi/admin/application/modules/default/controllers/IndexController.php
@@ -27,7 +27,7 @@ class IndexController extends Lupin_Controller_Base
     /**
      * Index action
      *
-     * The main index does nothing special. it verifies whether or not the 
+     * The main index does nothing special. it verifies whether or not the
      * setup can be ran by verifying the permissions on the custom directory
      * emits meesages when it's not.
      *
@@ -39,13 +39,13 @@ class IndexController extends Lupin_Controller_Base
         $user   = get_current_user();
 
         $dir = Zend_Registry::get('localConfigPath');
-        
+
         if (!is_writable($dir)) {
             $configPathMessage = $this->tr->_('ACTION_WARNING_CONFIG');
             $issues['config-path'] = sprintf($configPathMessage, $dir, $user);
         }
-        
-        $dir    = ROOT_PATH . DIRECTORY_SEPARATOR . 'custom' . DIRECTORY_SEPARATOR . 'Action';
+
+        $dir    = CUSTOM_PATH . DIRECTORY_SEPARATOR . 'Action';
 
         if (!is_writable($dir)) {
             $actionPathMessage = $this->tr->_('ACTION_WARNING_ACTION');
@@ -53,6 +53,6 @@ class IndexController extends Lupin_Controller_Base
         }
 
         $this->view->issues = $issues;
-        
+
     }
 }

--- a/src/frapi/admin/application/modules/default/models/Action.php
+++ b/src/frapi/admin/application/modules/default/models/Action.php
@@ -342,7 +342,7 @@ class Default_Model_Action extends Lupin_Model
             }
 
             $name = ucfirst(strtolower($a['name']));
-            $dir  = ROOT_PATH . DIRECTORY_SEPARATOR . 'custom' . DIRECTORY_SEPARATOR . 'Action';
+            $dir  = CUSTOM_PATH . DIRECTORY_SEPARATOR . 'Action';
 
             $file = $dir . DIRECTORY_SEPARATOR . $name . '.php';
 

--- a/src/frapi/admin/application/modules/default/models/Output.php
+++ b/src/frapi/admin/application/modules/default/models/Output.php
@@ -16,15 +16,15 @@
 class Default_Model_Output extends Lupin_Model
 {
     protected $config;
-    
+
     public function __construct()
     {
         $this->config = new Lupin_Config_Xml('outputs');
     }
-    
+
     public function sync()
     {
-        $path = ROOT_PATH . '/library/Frapi/Output/';
+        $path = LIBRARY_ROOT_PATH . DIRECTORY_SEPARATOR . 'Output' . DIRECTORY_SEPARATOR;
         $dir  = new DirectoryIterator($path);
         $data = array();
         foreach ($dir as $d) {
@@ -63,7 +63,7 @@ class Default_Model_Output extends Lupin_Model
         try {
             $this->config->update('output', 'name', $id, array('default' => '1'));
         } catch (Exception $e) {}
-        
+
         $this->refreshAPCCache();
     }
 
@@ -79,7 +79,7 @@ class Default_Model_Output extends Lupin_Model
         try {
             $this->config->update('output', 'name', $id, array('enabled' => '1'));
         } catch (Exception $e) {}
-        
+
         $this->refreshAPCCache();
     }
 
@@ -89,7 +89,7 @@ class Default_Model_Output extends Lupin_Model
         try {
             $this->config->update('output', 'name', $id, array('enabled' => '0'));
         } catch (Exception $e) {}
-        
+
         $this->refreshAPCCache();
     }
 
@@ -103,7 +103,7 @@ class Default_Model_Output extends Lupin_Model
         $configModel = new Default_Model_Configuration();
         $server = $configModel->getKey('api_url');
         $hash = isset($server) ? hash('sha1', $server) : '';
-        
+
         $cache = Frapi_Cache::getInstance(FRAPI_CACHE_ADAPTER);
 
         $cache->delete($hash . '-Output.default-format');

--- a/src/frapi/library/Frapi/AllFiles.php
+++ b/src/frapi/library/Frapi/AllFiles.php
@@ -19,7 +19,8 @@ if (!defined('ROOT_PATH')) {
     define('ROOT_PATH',         dirname(dirname(dirname(__FILE__))));
 }
 
-define('CUSTOM_PATH',       ROOT_PATH . DIRECTORY_SEPARATOR . 'custom');
+define('DEFAULT_CUSTOM_PATH', ROOT_PATH . DIRECTORY_SEPARATOR . 'custom');
+define('CUSTOM_PATH', (!isset($_SERVER['FRAPI_CUSTOM_PATH']) || !file_exists($_SERVER['FRAPI_CUSTOM_PATH'])) ? DEFAULT_CUSTOM_PATH : $_SERVER['FRAPI_CUSTOM_PATH']);
 define('LIBRARY_ROOT_PATH', ROOT_PATH . DIRECTORY_SEPARATOR . 'library' . DIRECTORY_SEPARATOR . 'Frapi');
 define('EXTRA_LIBRARIES_ROOT_PATH', ROOT_PATH . DIRECTORY_SEPARATOR . 'library' . DIRECTORY_SEPARATOR);
 


### PR DESCRIPTION
Allow setting of `CUSTOM_PATH` via a `FRAPI_CUSTOM_PATH` environment variable. Fixes #127
