### PR TITLE
Add Travis Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: php
+php:
+  - 5.3
+  - 5.4
+script: cd src/frapi/tests && phpunit -c phpunit.xml
+before_script:
+  - ./src/frapi/tests/travis-ci/install-apc.sh 
+notifications:
+  irc: "irc.freenode.org#frapi"

--- a/src/frapi/tests/travis-ci/install-apc.sh
+++ b/src/frapi/tests/travis-ci/install-apc.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+wget http://pecl.php.net/get/APC
+tar -xzf APC
+sh -c "cd APC-* && phpize && ./configure && sudo make install"
+echo "extension=apc.so
+[apc]
+apc.enabled = 1
+apc.enable_cli = 1" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`


### PR DESCRIPTION
This config adds a `.travis.yml` configuration, and a shell script for compiling `ext/apc` in the travis environment.

You can see see this in action on my fork, here: http://travis-ci.org/#!/dshafik/frapi

To enable it for the main frapi/frapi repo, an organization manager will need to follow the instructions here: http://about.travis-ci.org/docs/user/how-to-setup-and-trigger-the-hook-manually/
