### PR TITLE
Fix code to solve failing test

### DIFF
--- a/src/frapi/library/Frapi/Controller/Api.php
+++ b/src/frapi/library/Frapi/Controller/Api.php
@@ -244,7 +244,7 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
                   ->setActionParams($this->getParams())
                   ->setActionFiles($this->getFiles())
                   ->setAcceptParams(
-                      isset($this->options) && is_array($this->options) 
+                      isset($this->options) && is_array($this->options)
                       ? $this->options : array()
                   );
 
@@ -342,7 +342,7 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
         $types = $this->parseAcceptHeader();
 
         if(empty($types)) {
-            return false;
+            return array('mimeType' => false, 'outputFormat' => false);
         }
 
         if ($this->formatSetByExtension) {
@@ -395,7 +395,7 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
             }
         }
 
-        return array();
+        return array('mimeType' => false, 'outputFormat' => false);
     }
 
     /**


### PR DESCRIPTION
This is a small fix to solve a notice in a test when an unknown mimetype is used

It builds on to of #133 and means we get a clean CI test!
