### PR TITLE
When mime types are empty set values to null instead of false.

### DIFF
--- a/src/frapi/library/Frapi/Controller/Api.php
+++ b/src/frapi/library/Frapi/Controller/Api.php
@@ -344,7 +344,7 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
         $types = $this->parseAcceptHeader();
 
         if(empty($types)) {
-            return array('mimeType' => false, 'outputFormat' => false);
+            return array('mimeType' => null, 'outputFormat' => null);
         }
 
         if ($this->formatSetByExtension) {
@@ -397,7 +397,7 @@ class Frapi_Controller_Api extends Frapi_Controller_Main
             }
         }
 
-        return array('mimeType' => false, 'outputFormat' => false);
+        return array('mimeType' => null, 'outputFormat' => null);
     }
 
     /**


### PR DESCRIPTION
Same thing for outputFormat. Later in /library/Frapi/Output.php we use isset() to check the value.
Technically the boolean false counts as the value being set, so we end up with a "Class 'Frapi_Output_' not found" error.

I don't think there are any conditional statements checking for boolean values anywhere else but please correct me if I'm wrong.
