### PR TITLE
Re-write content negotiation to be more robust

### DIFF
--- a/src/frapi/library/Frapi/Output.php
+++ b/src/frapi/library/Frapi/Output.php
@@ -176,6 +176,10 @@ class Frapi_Output
     public static function getMimeTypeMap()
     {
         try {
+            if ($map = Frapi_Internal::getCached('Output.mimeMaps')) {
+                return $map;
+            }
+
             $cache = new Frapi_Internal();
             $mimetypes = $cache->getConfiguration('mimetypes')->getAll('mimetype');
 
@@ -200,7 +204,31 @@ class Frapi_Output
             return false;
         }
 
+        Frapi_Internal::setCached('Output.mimeMaps', $map);
+
         return $map;
+    }
+
+    /**
+     * Return a mimetype for a given extension
+     *
+     * @deprecated
+     * @param string $format
+     * @return string|false
+     */
+    public static function getMimeTypeByFormat($format)
+    {
+        $format = strtolower($format);
+
+        $mimeMap = array(
+            'xml' => 'application/xml',
+            'json' => 'application/json',
+            'html' => 'text/html',
+            'js' => 'text/javascript',
+            'printr' => 'text/php-printr',
+        );
+
+        return (isset($mimeMap[$format])) ? $mimeMap[$format] : false;
     }
 
     /**
@@ -225,8 +253,8 @@ class Frapi_Output
 
         $obj->type     = $type;
 
-        $obj->mimeType = isset($options['mimeType'])
-            ? $options['mimeType']
+        $obj->mimeType = isset($options['mimetype']) && $options['mimetype']
+            ? $options['mimetype']
             : $obj->mimeType;
 
         return $obj;

--- a/src/frapi/tests/mock/MockFrapi/Controller/Api.php
+++ b/src/frapi/tests/mock/MockFrapi/Controller/Api.php
@@ -2,5 +2,41 @@
 
 class MockFrapi_Controller_Api extends Frapi_Controller_Api
 {
-    public function __construct() {}
+    public function parseMimeTypes() {
+        $patterns = array(
+            array(
+                'mimetype' => 'application/vnd.test.:format',
+                'output_format' => ':format',
+                'hash' => 'adea02c1d8a51bdfbd41b9ee199cd3b19c0f249e',
+                'pattern' => '@^application/vnd\\.test\\.(?P<format>[^\.\+]*?)$@',
+                'params' =>
+                array(
+                    'format',
+                ),
+            ),
+            array(
+                'mimetype' => 'application/vnd.test.:version.:format',
+                'output_format' => ':format',
+                'hash' => 'adea02c1d8a51bdfbd41b9ee199c19c0f249e',
+                'pattern' => '@^application/vnd\\.test\\.(?P<version>[^\.\+]*?)\\.(?P<format>[^\.\+]*?)$@',
+                'params' =>
+                array(
+                    'version',
+                    'format',
+                ),
+            ),
+            array(
+                'mimetype' => 'application/vnd.test.:version+json',
+                'output_format' => 'json',
+                'hash' => 'adea02c1d8a51bdfbd41b9eec19c0f249e',
+                'pattern' => '@^application/vnd\\.test\\.(?P<version>[^\.\+]*?)\\+json$@',
+                'params' =>
+                array(
+                    'version',
+                ),
+            ),
+        );
+
+        return $patterns;
+    }
 }

--- a/src/frapi/tests/mock/MockFrapi/Controller/Main.php
+++ b/src/frapi/tests/mock/MockFrapi/Controller/Main.php
@@ -2,6 +2,9 @@
 
 class MockFrapi_Controller_Main extends Frapi_Controller_Main
 {
-    public function __construct() {}
+    public function getDefaultFormatFromConfiguration()
+    {
+        return 'JSON';
+    }
 
 }

--- a/src/frapi/tests/unit-tests/library/Frapi/Controller/ApiTest.php
+++ b/src/frapi/tests/unit-tests/library/Frapi/Controller/ApiTest.php
@@ -2,22 +2,55 @@
 
 class Frapi_Controller_ApiTest extends PHPUnit_Framework_TestCase
 {
-    protected $_controller;
-
     public function setUp()
     {
-        $this->_controller = new MockFrapi_Controller_Api();
+        Frapi_Internal::setCached('Output.mimeMaps', array (
+            'application/xml' => 'xml',
+            'text/xml' => 'xml',
+            'application/json' => 'json',
+            'text/json' => 'json',
+            'text/html' => 'html',
+            'text/plain' => 'json',
+            'text/javascript' => 'js',
+            'text/php-printr' => 'printr',
+            'application/vnd.test.:format' => ':format',
+            'application/vnd.test.:version.:format' => ':format',
+            'application/vnd.test.:version+json' => 'json',
+            'text/csv' => 'csv',
+        ));
     }
+
     /**
      * test various Accept header values, passed via acceptProvider
      *
      * @dataProvider acceptProvider
      */
-    public function testDetectMimeType($mimeType, $dataType)
+    public function testDetectFormats($accepts, $outputFormat, $mimetype, $params)
     {
-        $_SERVER['HTTP_ACCEPT'] = $mimeType;
-        $detectedOutputType = $this->_controller->detectAndSetMimeType();
-        $this->assertEquals($dataType, strtolower($detectedOutputType['outputFormat']));
+        $_SERVER['HTTP_ACCEPT'] = $accepts;
+
+        $controller = new MockFrapi_Controller_Api();
+        $detectedOutputType = $controller->detectOutputFormat();
+
+        $this->assertEquals($mimetype, strtolower($detectedOutputType['mimetype']), "Mimetypes do not match");
+        $this->assertEquals($outputFormat, strtolower($detectedOutputType['outputFormat']), "Output Formats do not match");
+        $this->assertEquals($params, $detectedOutputType['params'], "Params does not match");
+    }
+
+    /**
+     * test various REQUEST_URI extensions, passed via uriProvider
+     *
+     * @dataProvider uriProvider
+     */
+    public function testDetectExtensions($uri, $outputFormat, $mimetype)
+    {
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        $controller = new MockFrapi_Controller_Api();
+
+        $detectedOutputType = $controller->detectOutputFormat();
+        $this->assertEquals($mimetype, strtolower($detectedOutputType['mimetype']), "Mimetypes do not match");
+        $this->assertEquals($outputFormat, strtolower($detectedOutputType['outputFormat']), "Output Formats do not match");
     }
 
     /**
@@ -26,19 +59,74 @@ class Frapi_Controller_ApiTest extends PHPUnit_Framework_TestCase
     public function acceptProvider()
     {
         return array(
-            array('application/xml', 'xml'),
-            array('text/xml', 'xml'),
-            array('application/json', 'json'),
-            array('text/json', 'json'),
-            array('text/html', 'html'),
-            array('text/plain', 'json'),
-            array('text/javascript', 'js'),
-            array('text/php-printr', 'printr'),
-            array('text/html;q=0.9,text/json,application/json', 'json'),
-            array('text/php-printr,text/html;q=0.9,application/json;q=0.8', 'printr'),
-            array('text/plain;q=0.9,text/fake', 'json'),
-            array('text/plain,text/fake', 'json'),
-            array('text/fake', false)
+            /* Basic mimetypes */
+            array('application/xml', 'xml', 'application/xml', array()),
+            array('text/xml', 'xml', 'text/xml', array()),
+            array('application/json', 'json', 'application/json', array()),
+            array('text/json', 'json', 'text/json', array()),
+            array('text/html', 'html', 'text/html', array()),
+            array('text/plain', 'json', 'text/plain', array()),
+            array('text/javascript', 'js', 'text/javascript', array()),
+            array('text/php-printr', 'printr', 'text/php-printr', array()),
+
+            /* Test q-values */
+            array('text/html;q=0.9,text/json,application/json', 'json', 'text/json', array()),
+            array('text/php-printr,text/html;q=0.9,application/json;q=0.8', 'printr', 'text/php-printr', array()),
+
+            /* Test bad mimetypes return default */
+            array('text/fake', 'json', 'application/json', array()), /* @see MockFrapi_Controller_Main::getDefaultFormatFromConfiguration() */
+
+            /* Test q-values with bad mimetypes */
+            array('text/plain;q=0.9,text/fake', 'json', 'text/plain', array('q' => '0.9')),
+            array('text/fake,text/plain', 'json', 'text/plain', array()),
+
+            /* Make sure only the winning mimetype's params are returned */
+            array('text/json,text/html;q=1', 'json', 'text/json', array()),
+
+            /* Test mimetypes with params */
+            array('text/json;version=1,text/html;version=2', 'json', 'text/json', array('version' => 1)),
+            array('text/json;version=1;foo=bar,text/html;version=2', 'json', 'text/json', array('version' => 1, 'foo' => 'bar')),
+            array('text/json;version=1;foo=bar', 'json', 'text/json', array('version' => '1', 'foo' => 'bar')),
+
+            /* Test simple custom mimetype */
+            array('text/csv', 'csv', 'text/csv', array()),
+            array('text/csv;q=0.9,text/html', 'html', 'text/html', array()),
+
+            /* Test simple custom mimetype with params */
+            array('text/csv;q=0.9;version=1', 'csv', 'text/csv', array('q' => '0.9', 'version' => '1')),
+            array('text/csv;q=0.9;version=1,text/html;version=2', 'html', 'text/html', array('version' => '2')),
+            array('text/html;q=0.9,text/csv;version=1', 'csv', 'text/csv', array('version' => '1')),
+
+            /* Test custom mimetypes with placeholders and/or params */
+            array('application/vnd.test.json', 'json', 'application/vnd.test.json', array('format' => 'json')),
+            array('application/vnd.test.xml', 'xml', 'application/vnd.test.xml', array('format' => 'xml')),
+            array('application/vnd.test.json;version=1;foo=bar, application/json;q=0.9', 'json', 'application/vnd.test.json', array('format' => 'json', 'version' => '1', 'foo' => 'bar')),
+            array('application/vnd.test.v1+json, application/json;q=0.9', 'json', 'application/vnd.test.v1+json', array('version' => 'v1')),
+
+            /* Test custom mimetypes with multiple placeholders */
+            array('application/vnd.test.v1.json;foo=bar, application/json;q=0.9', 'json', 'application/vnd.test.v1.json', array('format' => 'json', 'version' => 'v1', 'foo' => 'bar')),
+            array('application/vnd.test.v1.json;q=0.9;foo=bar, application/vnd.test.json', 'json', 'application/vnd.test.json', array('format' => 'json')),
+
+            /* Test Bad Inputs */
+            array(null, 'json', 'application/json', array()),
+            array("&bad mimetype&", 'json', 'application/json', array()),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function uriProvider()
+    {
+        return array(
+            array('/foo.json', 'json', 'application/json'),
+            array('/foo.xml', 'xml', 'application/xml'),
+            array('/foo.html', 'html', 'text/html'),
+            array('/foo.js', 'js', 'text/javascript'),
+            array('/foo.printr', 'printr', 'text/php-printr'),
+
+            /* Test Multi-segment paths */
+            array('/foo/bar.json', 'json', 'application/json'),
         );
     }
 }


### PR DESCRIPTION
- **All** legacy behavior is correctly observed
- Extensions are now converted to mimetypes and _prepended_ to `HTTP_ACCEPT`
- Always respond with the requested mimetype (e.g. `text/vnd.myapp.v1+json`) regardless of output formatter used
- All output formats are chosen based on `HTTP_ACCEPT` _only_ (or config default)
- Fixed an issue in the handling of similar mimetypes with placeholders
- Rename setFormat to setOutputFormat to match setInputFormat
- Ensure that the mimetypes.xml is _optional_ and that previous behavior is the default
- **Fully unit test both the Accept and extension-based content-negotiation**

[![Build Status](https://secure.travis-ci.org/dshafik/frapi.png?branch=content-negotiation-overhaul-ci-merge)](http://travis-ci.org/dshafik/frapi)
