### PR TITLE
Add support for `application/javascript`

### DIFF
--- a/src/frapi/custom/Config/mimetypes.xml
+++ b/src/frapi/custom/Config/mimetypes.xml
@@ -49,5 +49,11 @@
    <description></description>
    <hash>033c878cd3cb4182ac91eb31f2332ddd63bcc463</hash>
   </mimetype>
+  <mimetype>
+   <mimetype>application/javascript</mimetype>
+   <output_format>js</output_format>
+   <description></description>
+   <hash>a506b559c823b77ae1c78bb114ff3bb356270f86</hash>
+  </mimetype>
  </mimetypes>
 </frapi-config>

--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -159,14 +159,15 @@ class Frapi_Controller_Main
      * @var array An array of mimetypes and their output types.
      */
     protected $mimeMaps = array(
-        'application/xml'  => 'xml',
-        'text/xml'         => 'xml',
-        'application/json' => 'json',
-        'text/json'        => 'json',
-        'text/html'        => 'html',
-        'text/plain'       => 'json',
-        'text/javascript'  => 'js',
-        'text/php-printr'  => 'printr'
+        'application/xml'           => 'xml',
+        'text/xml'                  => 'xml',
+        'application/json'          => 'json',
+        'text/json'                 => 'json',
+        'text/html'                 => 'html',
+        'text/plain'                => 'json',
+        'application/javascript'    => 'js',
+        'text/javascript'           => 'js',
+        'text/php-printr'           => 'printr'
     );
 
     /*

--- a/src/frapi/library/Frapi/Output.php
+++ b/src/frapi/library/Frapi/Output.php
@@ -224,7 +224,7 @@ class Frapi_Output
             'xml' => 'application/xml',
             'json' => 'application/json',
             'html' => 'text/html',
-            'js' => 'text/javascript',
+            'js' => 'application/javascript',
             'printr' => 'text/php-printr',
         );
 

--- a/src/frapi/library/Frapi/Output/JS.php
+++ b/src/frapi/library/Frapi/Output/JS.php
@@ -40,7 +40,7 @@ class Frapi_Output_JS extends Frapi_Output implements Frapi_Output_Interface
      *
      * @var string
      */
-    public $mimeType = 'text/javascript';
+    public $mimeType = 'application/javascript';
 
     /**
      * Populate the Output

--- a/src/frapi/tests/unit-tests/library/Frapi/Controller/ApiTest.php
+++ b/src/frapi/tests/unit-tests/library/Frapi/Controller/ApiTest.php
@@ -11,6 +11,7 @@ class Frapi_Controller_ApiTest extends PHPUnit_Framework_TestCase
             'text/json' => 'json',
             'text/html' => 'html',
             'text/plain' => 'json',
+            'application/javascript' => 'js',
             'text/javascript' => 'js',
             'text/php-printr' => 'printr',
             'application/vnd.test.:format' => ':format',
@@ -67,6 +68,7 @@ class Frapi_Controller_ApiTest extends PHPUnit_Framework_TestCase
             array('text/html', 'html', 'text/html', array()),
             array('text/plain', 'json', 'text/plain', array()),
             array('text/javascript', 'js', 'text/javascript', array()),
+            array('application/javascript', 'js', 'application/javascript', array()),
             array('text/php-printr', 'printr', 'text/php-printr', array()),
 
             /* Test q-values */
@@ -122,7 +124,7 @@ class Frapi_Controller_ApiTest extends PHPUnit_Framework_TestCase
             array('/foo.json', 'json', 'application/json'),
             array('/foo.xml', 'xml', 'application/xml'),
             array('/foo.html', 'html', 'text/html'),
-            array('/foo.js', 'js', 'text/javascript'),
+            array('/foo.js', 'js', 'application/javascript'),
             array('/foo.printr', 'printr', 'text/php-printr'),
 
             /* Test Multi-segment paths */


### PR DESCRIPTION
- Make `application/javascript` the default for .js
- Responds with application/javascript or text/javascript based on `Accept` header

[![Build Status](https://secure.travis-ci.org/dshafik/frapi.png?branch=add-application-javascript-mimetype)](http://travis-ci.org/dshafik/frapi)
