### PR TITLE
Access-Control-Allow-Headers does not allow * as accepted value

### DIFF
--- a/src/frapi/library/Frapi/Output.php
+++ b/src/frapi/library/Frapi/Output.php
@@ -145,7 +145,9 @@ class Frapi_Output
 
         if ($allowCrossDomain) {
             header('Access-Control-Allow-Origin: *');
-            header('Access-Control-Allow-Headers: *');
+            if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'])) {
+                header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
+            }
             header('Access-Control-Allow-Credentials: true');
             header('Access-Control-Allow-Methods: POST,GET,PUT,DELETE,HEAD');
             header('Access-Control-Max-Age: 604800');


### PR DESCRIPTION
I have been trying to implement Ext js 4 with FRAPI , and I had to change Access-Control-Allow-Headers: \* to avoid the "Request header field X-Requested-With is not allowed by Access-Control-Allow-Headers" error .

For more info the same issue related here 

http://stackoverflow.com/questions/8719276/cors-with-php-headers

with this small change I got the Ext 4 js  grid  working in rest proxy mode , connected to the FRAPI 
