### PR TITLE
Updated .gitmodules to replace the git:// protocol to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/frapi/admin/public/js/ace"]
 	path = src/frapi/admin/public/js/ace
-	url = git://github.com/ajaxorg/ace.git
+	url = https://github.com/ajaxorg/ace.git


### PR DESCRIPTION
Updated .gitmodules to replace the git:// protocol to https:// because of possible firewall issues.
