### PR TITLE
throw Frapi_Error by default in generated Actions

### DIFF
--- a/src/frapi/admin/application/modules/default/models/Action.php
+++ b/src/frapi/admin/application/modules/default/models/Action.php
@@ -525,7 +525,7 @@ class Default_Model_Action extends Lupin_Model
         if (!empty($properties)) {
             $executeActionBody = '        $valid = $this->hasRequiredParameters($this->requiredParams);
 if ($valid instanceof Frapi_Error) {
-    return $valid;
+    throw $valid;
 }';
         }
 


### PR DESCRIPTION
This commit fixes #109.
