### PR TITLE
Fix issue #180.

### DIFF
--- a/src/frapi/custom/Output/html/Introduction.html.tpl
+++ b/src/frapi/custom/Output/html/Introduction.html.tpl
@@ -317,18 +317,19 @@ $mimetypes = $grouped;
                                                 </tr>
                                                 <?php
                                             }
-                                        }
+                                        } else {
                                         ?>
                                         <tr>
                                             <td><?php echo $param['name']; ?></td>
                                                 <td class="param-required">
                                                     <?php
-                                                        echo isset($subparam['required']) && $subparam['required'] == '1'
+                                                        echo isset($param['required']) && $param['required'] == '1'
                                                         ? '<strong>&#10003;</strong>' : '<strong>&#10007;</strong>'
                                                     ?>
                                                 </td>
                                         </tr>
                                         <?php
+                                        }
                                     }
                                     ?>
                                 </table>


### PR DESCRIPTION
If there were multiple parameters for an action the template was also running the
code for a single parameter action. Added logic to prevent this, and use
proper variables when it happens.
