### PR TITLE
Fix parsing of input Content-Type with mimetype params

### DIFF
--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -519,9 +519,12 @@ class Frapi_Controller_Main
      */
     public function setInputFormat()
     {
-        $contentType = (isset($_SERVER['CONTENT_TYPE'])) ?
-                $_SERVER['CONTENT_TYPE'] :
-                null;
+        $contentType = null;
+        if (isset($_SERVER['CONTENT_TYPE'])) {
+            $matches = array();
+            preg_match('/^\s*(.*?)(?:(?:$|\s|;).*)/', $_SERVER['CONTENT_TYPE'], $matches);
+            $contentType = $matches[1];
+        }
 
         if(!empty($contentType) &&
            isset($this->mimeMaps[$contentType]) &&


### PR DESCRIPTION
FRAPI would error when request BODY content is sent, and a `Content-Type: text/plain;charset=utf8` header was passed, because this didn't exist in the mimetype map yet a body was still sent.
