### PR TITLE
Missing parenthesis added

### DIFF
--- a/src/frapi/admin/application/modules/default/views/scripts/docs/generate.phtml
+++ b/src/frapi/admin/application/modules/default/views/scripts/docs/generate.phtml
@@ -19,7 +19,7 @@
                 <p class="description"><?php echo $action['description'] ?></p>
             <?php endif; ?>
 
-            <?php if(isset($action['parameters'] && count($action['parameters'])): ?>
+            <?php if(isset($action['parameters'] ) && count($action['parameters'])): ?>
                 <h3>Parameters</h3>
                 <table class="doc-table">
                     <?php


### PR DESCRIPTION
/frapi/src/frapi/admin/application/modules/default/views/scripts/docs/generate.phtml was missing a ')'

It has been added. Have a great day and thanks for your work!

-nn
