### PR TITLE
Allow using Frapi_Action::getParam to access uploaded files.

### DIFF
--- a/src/frapi/library/Frapi/Action.php
+++ b/src/frapi/library/Frapi/Action.php
@@ -323,7 +323,11 @@ class Frapi_Action
      */
     protected function getParam($key, $type = self::TYPE_STRING, $default = null, $error_name = null)
     {
-         return $this->getByKey($this->getParams(), $key, $type, $default, $error_name);
+        if ($type == self::TYPE_FILE) {
+            return $this->getByKey($this->getFiles(), $key, $type, $default, $error_name);
+        }
+
+        return $this->getByKey($this->getParams(), $key, $type, $default, $error_name);
     }
 
     /**


### PR DESCRIPTION
Previously the getParam function always used the $_POST/params array.
This checks the type passed and if it is a file then uses the
$_FILES/files array instead. Fixes issue #202.
