### PR TITLE
Read error_reporting setting from system.

### DIFF
--- a/src/frapi/public/index.php
+++ b/src/frapi/public/index.php
@@ -1,7 +1,9 @@
 <?php
 
 require dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'library/Frapi/AllFiles.php';
-set_error_handler(array('Frapi_Error', 'errorHandler'), E_ALL);
+
+$error_reporting = ini_get('error_reporting');
+set_error_handler(array('Frapi_Error', 'errorHandler'), $error_reporting);
 ini_set('zlib.output_compression', 1);
 
 try {


### PR DESCRIPTION
Frapi works in E_ALL, but some peoples code does not. This allows them
to change it from their php.ini file if they are so inclined. Helps
alleviate issue #204.
