### PR TITLE
Always parse body if inputFormat is set

### DIFF
--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -348,7 +348,7 @@ class Frapi_Controller_Main
          * Checks if the last argument is an empty string, this + inputForm is
          * indicative of the body needing parsing.
          */
-        if (end($puts) == '' && !empty($inputFormat) || !empty($xmlJsonMatch)) {
+        if (!empty($inputFormat) || !empty($xmlJsonMatch)) {
             /* attempt to parse the input */
             reset($puts);
             $requestBody = Frapi_Input_RequestBodyParser::parse(

--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -328,29 +328,14 @@ class Frapi_Controller_Main
     {
         // read the raw input to get the request body
         $input = file_get_contents("php://input");
-        parse_str($input, $puts);
 
         $inputFormat = $this->inputFormat;
         if(empty($inputFormat)) {
-            $xmlJsonMatch = preg_grep('/\<|\{/i', array_keys($puts));
             $inputFormat = $this->getFormat();
         }
 
-        /**
-         * When doing parse_str("{json:string}") it creates an array like:
-         * array(
-         *  "{json:string}" => ""
-         * )
-         *
-         * If args are also present along with the body, they are in the array
-         * before the body.
-         *
-         * Checks if the last argument is an empty string, this + inputForm is
-         * indicative of the body needing parsing.
-         */
-        if (!empty($inputFormat) || !empty($xmlJsonMatch)) {
+        if (!empty($inputFormat)) {
             /* attempt to parse the input */
-            reset($puts);
             $requestBody = Frapi_Input_RequestBodyParser::parse(
                 $inputFormat,
                 $input
@@ -369,9 +354,12 @@ class Frapi_Controller_Main
 
                 $params = array_merge($params, $requestBody);
             }
-        } else if (!empty($puts)) {
-            foreach ($puts as $put => $val) {
-                $params[$put] = $val;
+        } else {
+            parse_str($input, $puts);
+            if (!empty($puts)) {
+                foreach ($puts as $put => $val) {
+                    $params[$put] = $val;
+                }
             }
         }
 


### PR DESCRIPTION
This was originally written as it was to avoid a BC issue, but it's possible to miss JSON input with more complex JSON structures.

``` json
{
    "var": {
        "test": false,
        "foo": "bar", 
        "baz": 0, 
        "bing": []
    },
}
```

This will result in the broken behavior.

If you are sending `Content-Type: application/json`, `Content-Type: application/xml` or similar, then you're probably wanting to send JSON or XML — I don't think this will be an issue.
