### PR TITLE
Handle mimetype params on input Content-Type header

### DIFF
--- a/src/frapi/library/Frapi/Controller/Main.php
+++ b/src/frapi/library/Frapi/Controller/Main.php
@@ -523,6 +523,11 @@ class Frapi_Controller_Main
                 $_SERVER['CONTENT_TYPE'] :
                 null;
 
+        if (strpos($contentType, ';') !== false) {
+            $parts = explode(';', $contentType);
+            $contentType = $parts[0];
+        }
+
         if(!empty($contentType) &&
            isset($this->mimeMaps[$contentType]) &&
            in_array($this->mimeMaps[$contentType], $this->allowedInputTypes)) {


### PR DESCRIPTION
This resolves an issue where FRAPI doesn't like `Content-Type: application/json;charset=utf-8`. The header is completely valid, and this is how Firefox sends it's XHR requests; currently breaking FRAPI.
