### PR TITLE
Updated javascript

### DIFF
--- a/src/frapi/admin/application/modules/default/views/scripts/tester/index.phtml
+++ b/src/frapi/admin/application/modules/default/views/scripts/tester/index.phtml
@@ -146,7 +146,7 @@ echo $this->form;
 
         queryURI += '.' + format.toLowerCase();
 
-        var finalParams = 'email=' + escape(email);
+        var finalParams = 'email=' + encodeURIComponent(email);
         finalParams += '&secretKey=' + key;
 
         switch (method.toLowerCase()) {
@@ -163,14 +163,14 @@ echo $this->form;
 
         finalParams += '&method=' + method;
         finalParams += '&url=' + url;
-        finalParams += '&query_uri=' + escape(queryURI);
+        finalParams += '&query_uri=' + encodeURIComponent(queryURI);
         if (ssl === true) {
             finalParams += '&ssl=true';
         }
 
         if (extraParams.length > 0) {
             for (var i = 0; i < extraParams.length; i++) {
-                finalParams += '&param[]=' + escape(extraParams[i]);
+                finalParams += '&param[]=' + encodeURIComponent(extraParams[i]);
             }
         }
 
@@ -229,7 +229,7 @@ echo $this->form;
                );
 
                var responseContent = '';
-               responseContent = $('<div id="response-code-container">').html($('<pre>').attr('id', 'response').addClass("brush: " + brush).html(unescape(data.content)));
+               responseContent = $('<div id="response-code-container">').html($('<pre>').attr('id', 'response').addClass("brush: " + brush).html(decodeURIComponent(data.content)));
 
 
                $('#response-container').attr('data-content', data.content).append(
@@ -294,7 +294,7 @@ echo $this->form;
             $.ajax({
                 type:    "GET",
                 url:     "/tester/history",
-                data:    "url=" + escape(queryURI),
+                data:    "url=" + encodeURIComponent(queryURI),
                 success: function(data) {
                     $("#query_uri").val(data.query_uri);
                     $("#format").attr("value", data.format.toUpperCase());


### PR DESCRIPTION
[According to MDN](https://developer.mozilla.org/en-US/docs/JavaScript/Guide/Functions#escape_and_unescape_functions%28Obsoleted_above_JavaScript_1.5%29), the escape/unescape functions in javascript are deprecated and instead encodeURIComponent/decodeURIComponent should be used.

I discovered this while I had some trouble with pluses being interpreted as spaces when using the Tester.

This patch replaces the javascript functions in use and fixes the issue.
