### PR TITLE
Fix Introduction.html.tpl

### DIFF
--- a/src/frapi/custom/Output/html/Introduction.html.tpl
+++ b/src/frapi/custom/Output/html/Introduction.html.tpl
@@ -320,7 +320,7 @@ $mimetypes = $grouped;
                                         }
                                         ?>
                                         <tr>
-                                            <td><?php echo $param['name']; ?></td>
+                                            <td><?php echo isset($param['name']) ? $param['name']: 'Missing Name'; ?></td>
                                                 <td class="param-required">
                                                     <?php
                                                         echo isset($subparam['required']) && $subparam['required'] == '1'


### PR DESCRIPTION
![screenshot from 2014-08-13 10 29 11](https://cloud.githubusercontent.com/assets/10982/3900591/e4fa7598-2291-11e4-8d18-16eb80412a3f.png)
Hi,

I found this problem when reviewing the code documentation. Especially when there are params on the description. The $param['name'] seems to be missing and frapi stops to function properly since the param['name'] is not set or missing.

This update will try to fix that.

This is the 4th Frapi installation I made, 2 of them are payment heavy API. Very good API core solution that fits my need.
